### PR TITLE
Revert "CMake: Increase min version to fix build on recent Fedora"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(zera-microcontroller LANGUAGES CXX)
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
It caused unforseeable results in zera-classes

This reverts commit ebe89ab601d2179ce67a5ae89619c8ba3aecad9d.